### PR TITLE
Make minimum required ruby version 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: 2.4
+      min_version: 2.5
 
   test:
     needs: ruby-versions

--- a/cmath.gemspec
+++ b/cmath.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = []
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.5.0"
 end

--- a/test/test_cmath.rb
+++ b/test/test_cmath.rb
@@ -6,7 +6,7 @@ class TestCMath < Test::Unit::TestCase
   def test_deprecated_method
     orig = $VERBOSE
     $VERBOSE = true
-    sqrt = assert_warning(/CMath#sqrt! is deprecated; use CMath#sqrt or Math#sqrt/) do
+    sqrt = assert_warning(/CMath#sqrt! is deprecated; use CMath#sqrt or Math#sqrt\Z/) do
       CMath.sqrt!(1)
     end
     assert_equal CMath.sqrt(1), sqrt


### PR DESCRIPTION
The current version is same as 2.5.

Also, `lib/cmath.rb` uses the `uplevel:` option of the `warn` method, which was added in Ruby 2.5. In Ruby 2.4 and earlier, the hash is output as is.